### PR TITLE
Limit build archtectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,10 @@ description: |
   sound and DOS. It's been designed to run old DOS games under platforms that
   don't support it.
 
+architectures:
+  - build-on: i386
+  - build-on: amd64
+
 confinement: strict
 grade: stable
 


### PR DESCRIPTION
It fails to build on anything but i386 and amd64, so limit to those for now.