### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
         # ./build-debug-no-avcodec
         ./build
         cp src/dosbox-x $SNAPCRAFT_PART_INSTALL
-        snapcraftctl set-version $(head -n 1 CHANGELOG | awk -F ' ' '{print $1}')
+        snapcraftctl set-version $(head -n 1 CHANGELOG | awk -F ' ' '{print $1}' | tr -d '\r')
     build-packages:
       - g++
       - make


### PR DESCRIPTION
Remove errant CR char on end of version string which fails when building.