### PR TITLE
nv-codec-headers: update branch name

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,7 +140,7 @@ parts:
   nv-codec-headers:
     plugin: make
     source: https://github.com/FFmpeg/nv-codec-headers.git
-    source-branch: 'sdk/10.0'
+    source-branch: 'old/sdk/10.0'
     override-build: |
       make install PREFIX=/usr
     build-packages:


### PR DESCRIPTION
The branch name for [`nv-codec-headers`](https://github.com/FFmpeg/nv-codec-headers.git) was changed to `old/sdk/10.0`.