### PR TITLE
version: get version using adopt-info

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,8 +67,6 @@ parts:
 
         # never fail on the next line (use `|| true` to ignore errors)
         desktop-file-edit --set-key=Icon --set-value='${SNAP}/usr/share/icons/hicolor/scalable/apps/dosbox-x.svg' $SNAPCRAFT_PART_INSTALL/usr/share/applications/com.dosbox_x.DOSBox-X.desktop || true
-
-        snapcraftctl set-version $(head -n 1 CHANGELOG | awk -F ' ' '{print $1}' | tr -d '\r')
     build-packages:
       - desktop-file-utils
       - g++


### PR DESCRIPTION
Previously, the version was being scraped from the first line of the [CHANGELOG](https://github.com/joncampbell123/dosbox-x/blob/master/CHANGELOG).  A few weeks ago, the dosbox-x developers added a `Next` section in the changelog.  This caused the version to be `Next`.

We're already using `adopt-info` for the summary.  It appears to work fine for setting the version too!